### PR TITLE
bump libevent to 2.1.12-stable

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,18 +1,18 @@
 package=libevent
-$(package)_version=2.1.8
-$(package)_download_path=https://github.com/libevent/libevent/archive
+$(package)_version=2.1.12-stable
+$(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_download_file=release-$($(package)_version)-stable.tar.gz
-$(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
+$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 
-define $(package)_preprocess_cmds
-  ./autogen.sh
-endef
-
+# When building for Windows, we set _WIN32_WINNT to target the same Windows
+# version as we do in configure. Due to quirks in libevents build system, this
+# is also required to enable support for ipv6. See #19375.
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress
+  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
+  $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
+  $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
 endef
 
 define $(package)_config_cmds
@@ -28,4 +28,7 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  rm lib/*.la && \
+  rm include/ev*.h && \
+  rm include/event2/*_compat.h
 endef


### PR DESCRIPTION
On Debian 12 Bookworm, the project fails to build due to the following error during the build of `libevent`:

```
/usr/bin/ld: /usr/bin/ld: ./.libs/libevent.a(evutil_rand.o): in function `evutil_secure_rng_add_bytes':
/daemon/depends/work/build/x86_64-unknown-linux-gnu/libevent/2.1.8-8948de65303/evutil_rand.c:198: undefined reference to `arc4random_addrandom'
...
collect2: error: ld returned 1 exit status
...
make: *** [funcs.mk:260: /daemon/depends/work/build/x86_64-unknown-linux-gnu/libevent/2.1.8-8948de65303/./.stamp_built] Error 2
```

This fix resolves the issue.