### PR TITLE
added DNS Seeder in Marmara codebase

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -185,6 +185,7 @@ public:
         // vSeeds.push_back(CDNSSeedData("komodoseeds.com", "kmd.komodoseeds.com")); // Static contolled seeds list (Kolo)
         // vSeeds.push_back(CDNSSeedData("komodoseeds.com", "dynamic.komodoseeds.com")); // Active seeds crawler (Kolo)
         // TODO: we need more seed crawlers from other community members
+        vSeeds.push_back(CDNSSeedData("seeds.marmara.io", "mcl.komodoseeds.org"));
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,60);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,85);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,188);


### PR DESCRIPTION
created A-records for seeds.marmara.io and added DNS Seeder in Marmara codebase as described in [here](https://github.com/marmarachain/marmara/pull/47#issuecomment-2363842926) 

built from this branch on `Ubuntu 20.04` machine:

Upon starting `marmarad`:
```
2024-10-09 12:14:06 dnsseed thread start
2024-10-09 12:14:06 Loading addresses from DNS seeds (could take a while)
2024-10-09 12:14:06 net thread start
2024-10-09 12:14:06 opencon thread start
2024-10-09 12:14:06 addcon thread start
2024-10-09 12:14:06 msghand thread start
2024-10-09 12:14:06 init message: Done loading
2024-10-09 12:14:06 marmara: MARMARA_POS_IMPROVEMENTS_HEIGHT=110777
2024-10-09 12:14:06 marmara: no '-pubkey' set, use -pubkey for mining
2024-10-09 12:14:12 3 addresses found from DNS seeds
2024-10-09 12:14:12 dnsseed thread exit
```