### PR TITLE
feat(consensus): auto checkpointing mechanism with a master nodeAuto checkpoints mcl

### DIFF
--- a/src/Gulden/auto_checkpoints.cpp
+++ b/src/Gulden/auto_checkpoints.cpp
@@ -1,0 +1,528 @@
+// Copyright (c) 2011-2013 The PPCoin developers
+// Copyright (c) 2015 The Gulden core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "checkpoints.h"
+#include "auto_checkpoints.h"
+#include "consensus/validation.h"
+
+#include "chainparams.h"
+#include "main.h"
+#include "uint256.h"
+#include "util.h"
+#include "txdb.h"
+#include "key.h"
+#include "pubkey.h"
+#include "timedata.h"
+
+#include <stdint.h>
+
+#include <boost/foreach.hpp>
+
+
+// Automatic checkpoint system.
+// Based on the checkpoint system developed initially by peercoin, however modified to work for Gulden.
+
+// How many blocks back the checkpoint should run
+#define AUTO_CHECKPOINT_DEPTH 4
+
+// ppcoin: synchronized checkpoint (centrally broadcasted)
+namespace Checkpoints
+{
+	uint256 hashSyncCheckpoint = uint256();
+	uint256 hashPendingCheckpoint = uint256();
+	CSyncCheckpoint checkpointMessage;
+	CSyncCheckpoint checkpointMessagePending;
+	uint256 hashInvalidCheckpoint = uint256();
+	CCriticalSection cs_hashSyncCheckpoint;
+
+
+	// Get the highest auto synchronized checkpoint that we have received
+	CBlockIndex* GetLastSyncCheckpoint()
+	{
+		LOCK(cs_hashSyncCheckpoint);
+		if (!mapBlockIndex.count(hashSyncCheckpoint))
+		{
+			error("GetSyncCheckpoint: block index missing for current sync-checkpoint %s", hashSyncCheckpoint.ToString().c_str());
+		}
+		else
+		{
+			return mapBlockIndex[hashSyncCheckpoint];
+		}
+		return NULL;
+	}
+
+	// Check if an auto synchronized checkpoint we have received is valid
+	// If it is on a fork (i.e. not a descendant of the current checkpoint) then we have a problem.
+	bool ValidateSyncCheckpoint(uint256 hashCheckpoint)
+	{
+		if (!mapBlockIndex.count(hashCheckpoint))
+		{
+			return error("ValidateSyncCheckpoint: block index missing for received sync-checkpoint %s", hashCheckpoint.ToString().c_str());
+		}
+		if (hashSyncCheckpoint==uint256())
+		{
+			return true;
+		}
+		if (!mapBlockIndex.count(hashSyncCheckpoint))
+		{
+			return error("ValidateSyncCheckpoint: block index missing for current sync-checkpoint %s", hashSyncCheckpoint.ToString().c_str());
+		}
+
+
+		CBlockIndex* pindexSyncCheckpoint = mapBlockIndex[hashSyncCheckpoint];
+		CBlockIndex* pindexCheckpointRecv = mapBlockIndex[hashCheckpoint];
+
+		if (pindexCheckpointRecv->nHeight <= pindexSyncCheckpoint->nHeight)
+		{
+			// Received an older checkpoint, trace back from current checkpoint
+			// to the same height of the received checkpoint to verify
+			// that current checkpoint should be a descendant block
+			CBlockIndex* pindex = pindexSyncCheckpoint;
+			while (pindex->nHeight > pindexCheckpointRecv->nHeight)
+			{
+				if (!(pindex = pindex->pprev))
+					return error("ValidateSyncCheckpoint: pprev1 null - block index structure failure");
+			}
+			if (pindex->GetBlockHash() != hashCheckpoint)
+			{
+				hashInvalidCheckpoint = hashCheckpoint;
+				return error("ValidateSyncCheckpoint: new sync-checkpoint %s is conflicting with current sync-checkpoint %s", hashCheckpoint.ToString().c_str(), hashSyncCheckpoint.ToString().c_str());
+			}
+			return false; // ignore older checkpoint
+		}
+
+		// Received checkpoint should be a descendant block of the current
+		// checkpoint. Trace back to the same height of current checkpoint
+		// to verify.
+		CBlockIndex* pindex = pindexCheckpointRecv;
+		while (pindex->nHeight > pindexSyncCheckpoint->nHeight)
+		{
+			if (!(pindex = pindex->pprev))
+			{
+				return error("ValidateSyncCheckpoint: pprev2 null - block index structure failure");
+			}
+		}
+		if (pindex->GetBlockHash() != hashSyncCheckpoint)
+		{
+			hashInvalidCheckpoint = hashCheckpoint;
+			return error("ValidateSyncCheckpoint: new sync-checkpoint %s is not a descendant of current sync-checkpoint %s", hashCheckpoint.ToString().c_str(), hashSyncCheckpoint.ToString().c_str());
+		}
+
+		return true;
+	}
+
+	// Save the current auto sync checkpoint to disk
+	bool WriteSyncCheckpoint(const uint256& hashCheckpoint)
+	{
+		CCheckpointsDB checkpointsDB;
+		if (!checkpointsDB.WriteSyncCheckpoint(hashCheckpoint))
+		{
+			return error("WriteSyncCheckpoint(): failed to write to db sync checkpoint %s", hashCheckpoint.ToString().c_str());
+		}
+		Checkpoints::hashSyncCheckpoint = hashCheckpoint;
+		return true;
+	}
+
+
+	bool AcceptPendingSyncCheckpoint()
+	{
+		LOCK(cs_hashSyncCheckpoint);
+		if (hashPendingCheckpoint != uint256() && mapBlockIndex.count(hashPendingCheckpoint))
+		{
+			if (!ValidateSyncCheckpoint(hashPendingCheckpoint))
+			{
+				hashPendingCheckpoint = uint256();
+				checkpointMessagePending.SetNull();
+				return false;
+			}
+
+			CBlockIndex* pindexCheckpoint = mapBlockIndex[hashPendingCheckpoint];
+			if (! (chainActive.Contains(pindexCheckpoint)) )
+			{
+				CBlock block;
+				if (!ReadBlockFromDisk(block, pindexCheckpoint, false))
+				{
+					return error("AcceptPendingSyncCheckpoint: ReadBlockFromDisk failed for sync checkpoint %s", hashPendingCheckpoint.ToString().c_str());
+				}
+				CValidationState state;
+				if (!ActivateBestChain(true, state, &block))
+				{
+					hashInvalidCheckpoint = hashPendingCheckpoint;
+					return error("AcceptPendingSyncCheckpoint: SetBestChain failed for sync checkpoint %s", hashPendingCheckpoint.ToString().c_str());
+				}
+			}
+
+			if (!WriteSyncCheckpoint(hashPendingCheckpoint))
+			{
+				return error("AcceptPendingSyncCheckpoint(): failed to write sync checkpoint %s", hashPendingCheckpoint.ToString().c_str());
+			}
+			hashPendingCheckpoint = uint256();
+			checkpointMessage = checkpointMessagePending;
+			checkpointMessagePending.SetNull();
+			LogPrintf("AcceptPendingSyncCheckpoint : sync-checkpoint at %s\n", hashSyncCheckpoint.ToString().c_str());
+
+			// relay the checkpoint
+			if (!checkpointMessage.IsNull())
+			{
+				BOOST_FOREACH(CNode* pnode, vNodes)
+				{
+					checkpointMessage.RelayTo(pnode);
+				}
+			}
+			return true;
+		}
+		return false;
+	}
+
+	// Check against synchronized checkpoint
+	bool CheckSync(const uint256& hashBlock, const CBlockIndex* pindexPrev)
+	{
+		int nHeight = pindexPrev->nHeight + 1;
+		LOCK(cs_hashSyncCheckpoint);
+		if (hashSyncCheckpoint==uint256())
+		{
+            return true;
+		}
+
+		// sync-checkpoint should always be accepted block
+		assert(mapBlockIndex.count(hashSyncCheckpoint));
+		const CBlockIndex* pindexSync = mapBlockIndex[hashSyncCheckpoint];
+
+		if (nHeight > pindexSync->nHeight)
+		{
+			// trace back to same height as sync-checkpoint
+			const CBlockIndex* pindex = pindexPrev;
+			while (pindex->nHeight > pindexSync->nHeight)
+			{
+				if (!(pindex = pindex->pprev))
+				{
+					return error("CheckSync: pprev null - block index structure failure");
+				}
+			}
+			if (pindex->nHeight < pindexSync->nHeight || pindex->GetBlockHash() != hashSyncCheckpoint)
+			{
+				return false; // only descendant of sync-checkpoint can pass check
+			}
+		}
+		if (nHeight == pindexSync->nHeight && hashBlock != hashSyncCheckpoint)
+		{
+			return false; // same height with sync-checkpoint
+		}
+		if (nHeight < pindexSync->nHeight && !mapBlockIndex.count(hashBlock))
+		{
+			return false; // lower height than sync-checkpoint
+		}
+		return true;
+	}
+
+	bool IsSecuredBySyncCheckpoint(const uint256& hashBlock)
+	{
+        if (hashSyncCheckpoint==uint256())
+			return false;
+		assert(mapBlockIndex.count(hashSyncCheckpoint));
+		const CBlockIndex* pindexSync = mapBlockIndex[hashSyncCheckpoint];
+		const CBlockIndex* pindex = mapBlockIndex[hashBlock];
+
+		if(!pindexSync || !pindex || pindex->nHeight >= pindexSync->nHeight)
+			return false;
+
+		return true;
+	}
+
+	bool WantedByPendingSyncCheckpoint(uint256 hashBlock)
+	{
+		LOCK(cs_hashSyncCheckpoint);
+		if (hashPendingCheckpoint == uint256())
+		{
+			return false;
+		}
+		if (hashBlock == hashPendingCheckpoint)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	// Reset synchronized checkpoint to last hardened checkpoint (to be used if checkpoint key is changed for whatever reason - e.g. a stalled chain)
+	bool ResetSyncCheckpoint()
+	{
+		LOCK(cs_hashSyncCheckpoint);
+
+		const CChainParams& chainparams = Params();
+		const uint256& hash = GetLastCheckpoint(chainparams.Checkpoints())->GetBlockHash();
+		if (mapBlockIndex.count(hash) && !chainActive.Contains(mapBlockIndex[hash]))
+		{
+			// checkpoint block accepted but not yet in main chain
+			LogPrintf("ResetSyncCheckpoint: SetBestChain to hardened checkpoint %s\n", hash.ToString().c_str());
+			CBlock block;
+			if (!ReadBlockFromDisk(block, mapBlockIndex[hash], false))
+			{
+				return error("ResetSyncCheckpoint: ReadBlockFromDisk failed for hardened checkpoint %s", hash.ToString().c_str());
+			}
+			CValidationState state;
+			if (!ActivateBestChain(true, state, &block))
+			{
+				return error("ResetSyncCheckpoint: ActivateBestChain failed for hardened checkpoint %s", hash.ToString().c_str());
+			}
+		}
+		if(mapBlockIndex.count(hash) && chainActive.Contains(mapBlockIndex[hash]))
+		{
+			if (!WriteSyncCheckpoint(hash))
+			{
+				return error("ResetSyncCheckpoint: failed to write sync checkpoint %s", hash.ToString().c_str());
+			}
+			LogPrintf("ResetSyncCheckpoint: sync-checkpoint reset to %s\n", hashSyncCheckpoint.ToString().c_str());
+			return true;
+		}
+		return false;
+	}
+
+	void AskForPendingSyncCheckpoint(CNode* pfrom)
+	{
+		LOCK(cs_hashSyncCheckpoint);
+		if (pfrom && hashPendingCheckpoint != uint256() && (!mapBlockIndex.count(hashPendingCheckpoint)))
+		{
+			pfrom->AskFor(CInv(MSG_BLOCK, hashPendingCheckpoint));
+		}
+	}
+
+	// Automatically select a suitable sync-checkpoint to broadcast [Checkpoint server only]
+	uint256 AutoSelectSyncCheckpoint()
+	{
+		// Proof-of-work blocks are immediately checkpointed
+		// to defend against 51% attack which rejects other miners block 
+
+		// Select the last proof-of-work block
+		CBlockIndex *pindex = chainActive.Tip();
+		if (pindex->nHeight < AUTO_CHECKPOINT_DEPTH+1)
+		{
+			return pindex->GetBlockHash();
+		}
+
+		// Search backwards AUTO_CHECKPOINT_DEPTH blocks
+		for(int i=0;i<AUTO_CHECKPOINT_DEPTH;i++)
+		{
+			pindex = pindex->pprev;
+		}
+
+		return pindex->GetBlockHash();
+	}
+
+	// Set the private key with which to broadcast checkpoints [Checkpoint server only]
+	bool SetCheckpointPrivKey(std::string strPrivKey)
+	{
+		// Test signing a sync-checkpoint with genesis block
+		CSyncCheckpoint checkpoint;
+		checkpoint.hashCheckpoint = uint256();
+		CDataStream sMsg(SER_NETWORK, PROTOCOL_VERSION);
+		sMsg << (CUnsignedSyncCheckpoint)checkpoint;
+		checkpoint.vchMsg = std::vector<unsigned char>(sMsg.begin(), sMsg.end());
+
+		std::vector<unsigned char> vchPrivKey = ParseHex(strPrivKey);
+		CKey key;
+		key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end()), false);
+		if (!key.Sign(Hash(checkpoint.vchMsg.begin(), checkpoint.vchMsg.end()), checkpoint.vchSig))
+		{
+			return false;
+		}
+
+		// Test signing successful, proceed
+		CSyncCheckpoint::strMasterPrivKey = strPrivKey;
+		return true;
+	}
+
+	// Broadcast a new checkpoint to the network [Checkpoint server only]
+	bool SendSyncCheckpoint(uint256 hashCheckpoint)
+	{
+		CSyncCheckpoint checkpoint;
+		checkpoint.hashCheckpoint = hashCheckpoint;
+		CDataStream sMsg(SER_NETWORK, PROTOCOL_VERSION);
+		sMsg << (CUnsignedSyncCheckpoint)checkpoint;
+		checkpoint.vchMsg = std::vector<unsigned char>(sMsg.begin(), sMsg.end());
+
+		if (CSyncCheckpoint::strMasterPrivKey.empty())
+		{
+			return error("SendSyncCheckpoint: Checkpoint master key unavailable.");
+		}
+
+		std::vector<unsigned char> vchPrivKey = ParseHex(CSyncCheckpoint::strMasterPrivKey);
+		CKey key;
+		key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end()), false); // if key is not correct openssl may crash
+
+		if (!key.Sign(Hash(checkpoint.vchMsg.begin(), checkpoint.vchMsg.end()), checkpoint.vchSig))
+		{
+			return error("SendSyncCheckpoint: Unable to sign checkpoint, check private key?");
+		}
+
+		if(!checkpoint.ProcessSyncCheckpoint(NULL))
+		{
+			LogPrintf("WARNING: SendSyncCheckpoint: Failed to process checkpoint.\n");
+			return false;
+		}
+		else
+		{
+			LogPrintf("SendSyncCheckpoint: SUCCESS.\n");
+		}
+
+		// Relay checkpoint
+		{
+			LOCK(cs_vNodes);
+			BOOST_FOREACH(CNode* pnode, vNodes)
+			{
+				checkpoint.RelayTo(pnode);
+			}
+		}
+		return true;
+	}
+
+	// Is the sync-checkpoint too old?
+	bool IsSyncCheckpointTooOld(unsigned int nSeconds)
+	{
+		LOCK(cs_hashSyncCheckpoint);
+		if (hashSyncCheckpoint==uint256())
+		{
+			return true;
+		}
+		// sync-checkpoint should always be accepted block
+		assert(mapBlockIndex.count(hashSyncCheckpoint));
+		const CBlockIndex* pindexSync = mapBlockIndex[hashSyncCheckpoint];
+		return (pindexSync->GetBlockTime() + nSeconds < GetTime()); // TODO: was GetAdjustedTime
+	}
+}
+
+//Gulden checkpoint key public signature
+const std::string CSyncCheckpoint::strMasterPubKey		= "04cf0c4e9be8421b9c7e83dc5a361a16a0cd784d027a9213cf9c6ce9599c5d5450dc80e3fdbfa80523216cda9eb3eff8b97f05f8823ded47067a661bc1f6f7780e";
+const std::string CSyncCheckpoint::strMasterPubKeyTestnet  	= "04cf0c4e9be8421b9c7e83dc5a361a16a0cd784d027a9213cf9c6ce9599c5d5450dc80e3fdbfa80523216cda9eb3eff8b97f05f8823ded47067a661bc1f6f7780e";
+
+std::string CSyncCheckpoint::strMasterPrivKey = "";
+
+// ppcoin: verify signature of sync-checkpoint message
+bool CSyncCheckpoint::CheckSignature()
+{
+	CPubKey key(ParseHex(GetBoolArg("-testnet", false) ? CSyncCheckpoint::strMasterPubKeyTestnet : CSyncCheckpoint::strMasterPubKey));
+	if (!key.IsValid())
+	{
+		return error("CSyncCheckpoint::CheckSignature() : SetPubKey failed");
+	}
+	if (!key.Verify(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
+	{
+		return error("CSyncCheckpoint::CheckSignature() : verify signature failed");
+	}
+
+	// Now unserialize the data
+	CDataStream sMsg(vchMsg, SER_NETWORK, PROTOCOL_VERSION);
+	sMsg >> *(CUnsignedSyncCheckpoint*)this;
+	return true;
+}
+
+// ppcoin: process synchronized checkpoint
+bool CSyncCheckpoint::ProcessSyncCheckpoint(CNode* pfrom)
+{
+	if (!CheckSignature())
+	{
+		return false;
+	}
+
+	LOCK(Checkpoints::cs_hashSyncCheckpoint);
+	
+	if (!mapBlockIndex.count(hashCheckpoint))
+	{
+		// We haven't received the checkpoint chain, keep the checkpoint as pending
+		Checkpoints::hashPendingCheckpoint = hashCheckpoint;
+		Checkpoints::checkpointMessagePending = *this;
+		LogPrintf("ProcessSyncCheckpoint: pending for sync-checkpoint %s\n", hashCheckpoint.ToString().c_str());
+		// Ask this guy to fill in what we're missing
+		if (pfrom)
+		{
+			pfrom->PushMessage("getheaders", chainActive.GetLocator(chainActive.Tip()), uint256());
+		}
+		return false;
+	}
+
+	if (!Checkpoints::ValidateSyncCheckpoint(hashCheckpoint))
+	{
+		return false;
+	}
+
+	CBlockIndex* pindexCheckpoint = mapBlockIndex[hashCheckpoint];
+	if (!chainActive.Contains(pindexCheckpoint))
+	{
+		// checkpoint chain received but not yet main chain
+		CBlock block;
+		if (!ReadBlockFromDisk(block, pindexCheckpoint, false))
+		{
+			return error("ProcessSyncCheckpoint: ReadBlockFromDisk failed for sync checkpoint %s", hashCheckpoint.ToString().c_str());
+		}
+
+		CValidationState state;
+		if (!ActivateBestChain(true, state, &block))
+		{
+			Checkpoints::hashInvalidCheckpoint = hashCheckpoint;
+			return error("ProcessSyncCheckpoint: ActivateBestChain failed for sync checkpoint %s", hashCheckpoint.ToString().c_str());
+		}
+	}
+
+	if (!Checkpoints::WriteSyncCheckpoint(hashCheckpoint))
+	{
+		return error("ProcessSyncCheckpoint(): failed to write sync checkpoint %s", hashCheckpoint.ToString().c_str());
+	}
+
+	Checkpoints::checkpointMessage = *this;
+	Checkpoints::hashPendingCheckpoint = uint256();
+	Checkpoints::checkpointMessagePending.SetNull();
+	LogPrintf("ProcessSyncCheckpoint: sync-checkpoint at %s\n", hashCheckpoint.ToString().c_str());
+	return true;
+}
+
+
+void CUnsignedSyncCheckpoint::SetNull()
+{
+	nVersion = 1;
+	hashCheckpoint = uint256();
+}
+
+std::string CUnsignedSyncCheckpoint::ToString() const
+{
+	return strprintf("CSyncCheckpoint(\n    nVersion       = %d\n    hashCheckpoint = %s\n)\n", nVersion, hashCheckpoint.ToString().c_str());
+}
+
+void CUnsignedSyncCheckpoint::print() const
+{
+	LogPrintf("%s", ToString().c_str());
+}
+
+CSyncCheckpoint::CSyncCheckpoint()
+{
+	SetNull();
+}
+
+void CSyncCheckpoint::SetNull()
+{
+	CUnsignedSyncCheckpoint::SetNull();
+	vchMsg.clear();
+	vchSig.clear();
+}
+
+bool CSyncCheckpoint::IsNull() const
+{
+	return (hashCheckpoint == uint256());
+}
+
+uint256 CSyncCheckpoint::GetHash() const
+{
+	return SerializeHash(*this);
+}
+
+bool CSyncCheckpoint::RelayTo(CNode* pnode) const
+{
+	// returns true if wasn't already sent
+	if (pnode->hashCheckpointKnown != hashCheckpoint)
+	{
+		pnode->hashCheckpointKnown = hashCheckpoint;
+		pnode->PushMessage("checkpoint", *this);
+		return true;
+	}
+	return false;
+}

--- a/src/Gulden/auto_checkpoints.cpp
+++ b/src/Gulden/auto_checkpoints.cpp
@@ -41,7 +41,7 @@ namespace fs = boost::filesystem;
 // Adapted for Komodo as replacement for dPoW being sunset.
 
 // How many blocks back the checkpoint should run
-#define AUTO_CHECKPOINT_DEPTH 4
+#define AUTO_CHECKPOINT_DEPTH 10
 const std::string SYNC_CHKPT_DIR = "sync_checkpoint";
 const std::string SYNC_CHKPT_NEW = "new_checkpoint";
 const std::string SYNC_CHKPT_CURR = "curr_checkpoint";

--- a/src/Gulden/auto_checkpoints.h
+++ b/src/Gulden/auto_checkpoints.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2011-2013 The PPCoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef GULDEN_AUTO_CHECKPOINT_H
+#define  GULDEN_AUTO_CHECKPOINT_H
+
+#include <map>
+#include "net.h"
+#include "util.h"
+
+class uint256;
+class CBlockIndex;
+class CSyncCheckpoint;
+
+namespace Checkpoints
+{
+	extern uint256 hashSyncCheckpoint;
+	extern uint256 hashPendingCheckpoint;
+	extern CSyncCheckpoint checkpointMessage;
+	extern CSyncCheckpoint checkpointMessagePending;
+	extern uint256 hashInvalidCheckpoint;
+	extern CCriticalSection cs_hashSyncCheckpoint;
+	extern CBlockIndex* GetLastSyncCheckpoint();
+	extern bool ValidateSyncCheckpoint(uint256 hashCheckpoint);
+	extern bool WriteSyncCheckpoint(const uint256& hashCheckpoint);
+	extern bool AcceptPendingSyncCheckpoint();
+	extern uint256 AutoSelectSyncCheckpoint();
+	extern bool CheckSync(const uint256& hashBlock, const CBlockIndex* pindexPrev);
+	extern bool IsSecuredBySyncCheckpoint(const uint256& hashBlock);
+	extern bool WantedByPendingSyncCheckpoint(uint256 hashBlock);
+	extern bool ResetSyncCheckpoint();
+	extern void AskForPendingSyncCheckpoint(CNode* pfrom);
+	extern bool SetCheckpointPrivKey(std::string strPrivKey);
+	extern bool SendSyncCheckpoint(uint256 hashCheckpoint);
+	extern bool IsSyncCheckpointTooOld(unsigned int nSeconds);
+}
+
+class CUnsignedSyncCheckpoint
+{
+public:
+	int nVersion;
+	uint256 hashCheckpoint;      // checkpoint block
+
+	ADD_SERIALIZE_METHODS;
+	template <typename Stream, typename Operation>
+	inline void SerializationOp(Stream& s, Operation ser_action)
+	{
+		READWRITE(this->nVersion);
+		READWRITE(hashCheckpoint);
+	}
+	void SetNull();
+	std::string ToString() const;
+	void print() const;
+};
+
+class CSyncCheckpoint : public CUnsignedSyncCheckpoint
+{
+public:
+	static const std::string strMasterPubKey;
+	static const std::string strMasterPubKeyTestnet;
+	static std::string strMasterPrivKey;
+
+	std::vector<unsigned char> vchMsg;
+	std::vector<unsigned char> vchSig;
+
+	CSyncCheckpoint();
+	ADD_SERIALIZE_METHODS;
+	template <typename Stream, typename Operation>
+	inline void SerializationOp(Stream& s, Operation ser_action)
+	{
+		READWRITE(vchMsg);
+		READWRITE(vchSig);
+	}
+	void SetNull();
+	bool IsNull() const;
+	uint256 GetHash() const;
+	bool RelayTo(CNode* pnode) const;
+	bool CheckSignature();
+	bool ProcessSyncCheckpoint(CNode* pfrom);
+};
+#endif

--- a/src/Gulden/auto_checkpoints.h
+++ b/src/Gulden/auto_checkpoints.h
@@ -40,8 +40,11 @@ namespace Checkpoints
 {
     // Asset or KMD chain sync checkpoint activation params
     struct CSyncChkParams {
-        int64_t activeAt;
+        int64_t activeAt = -1;
         std::string masterPubKey;
+        
+        CSyncChkParams() = default;
+        CSyncChkParams(int64_t at, const std::string& key) : activeAt(at), masterPubKey(key) {}
     };
 	extern bool fTryInitDone;
 

--- a/src/Gulden/auto_checkpoints_activation.cpp
+++ b/src/Gulden/auto_checkpoints_activation.cpp
@@ -1,0 +1,202 @@
+/******************************************************************************
+ * Copyright © 2025 The SuperNET Developers.                                  *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * SuperNET software, including this file may be copied, modified, propagated *
+ * or distributed except according to the terms contained in the LICENSE file *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+// Sync checkpoint activation params for asset chains
+
+#include <map>
+#include <vector>
+#include <string>
+#include "key.h"
+#include "key_io.h"
+#include "main.h"
+#include "wallet/wallet.h"
+#include "init.h"
+#include "auto_checkpoints.h"
+#include "komodo_defs.h" 
+
+using namespace std;
+
+namespace Checkpoints
+{
+    struct CSyncCheckpointActivation {
+        map<string, CSyncChkParams> asset_chains;
+        boost::optional<CSyncChkParams> mainnet_params;
+        boost::optional<CSyncChkParams> testnet_params;
+
+        // TODO: fix master key
+        CSyncCheckpointActivation() {
+            mainnet_params = boost::none;
+            testnet_params = boost::none;
+
+            asset_chains = {
+                { "MCL", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }}
+            };
+        }
+
+        static bool GetAssetParams(const string &chain, CSyncChkParams &syncChkParams);
+        static bool GetMainnetParams(CSyncChkParams &syncChkParams);
+        static bool GetTestnetParams(CSyncChkParams &syncChkParams);
+        static bool GetChainParams(CSyncChkParams &syncChkParams);
+    };
+
+    static CSyncCheckpointActivation syncChkActivation;
+
+    bool CSyncCheckpointActivation::GetAssetParams(const string &chain, CSyncChkParams &syncChkParamsOut)
+    {
+        if (syncChkActivation.asset_chains.find(chain) != syncChkActivation.asset_chains.end()) {
+            syncChkParamsOut = syncChkActivation.asset_chains[chain];
+            return true;
+        }
+        return false;
+    }
+    bool CSyncCheckpointActivation::GetMainnetParams(CSyncChkParams &syncChkParamsOut)
+    {
+        if (syncChkActivation.mainnet_params) {
+            syncChkParamsOut = *syncChkActivation.mainnet_params;
+            return true;
+        }
+        return false;
+    }
+    bool CSyncCheckpointActivation::GetTestnetParams(CSyncChkParams &syncChkParamsOut)
+    {
+        if (syncChkActivation.testnet_params) {
+            syncChkParamsOut = *syncChkActivation.testnet_params;
+            return true;
+        }
+        return false;
+    }
+
+    bool CSyncCheckpointActivation::GetChainParams(CSyncChkParams &syncChkParamsOut)
+    {
+        if (ASSETCHAINS_SYMBOL[0] == 0) {
+            if (GetBoolArg("-testnet", false)) {
+                if (!CSyncCheckpointActivation::GetTestnetParams(syncChkParamsOut)) {
+                    return false;
+                }
+            } else {
+                if (!CSyncCheckpointActivation::GetMainnetParams(syncChkParamsOut)) {
+                    return false;
+                }
+            }
+        } else if (!CSyncCheckpointActivation::GetAssetParams(string(ASSETCHAINS_SYMBOL), syncChkParamsOut)) {
+            LogPrint("chk", "CSyncCheckpointActivation::GetChainParams: GetAssetParams returned false, ASSETCHAINS_SYMBOL=%s\n", ASSETCHAINS_SYMBOL);
+            return false;
+        }
+        return true;
+    }
+
+
+    // Is Gulden sync checkpoints active for this chain and height or timestamp
+    static bool GetSyncCheckpointActivationParams(CSyncChkParams &syncChkParamsOut, int nHeight, int64_t timestamp) {
+        AssertLockHeld(cs_main);
+        if (!CSyncCheckpointActivation::GetChainParams(syncChkParamsOut))
+            return false;
+
+        if (syncChkParamsOut.activeAt < LOCKTIME_THRESHOLD) { // height or timestamp
+            if (nHeight > syncChkParamsOut.activeAt) { // same 'greater' comparison as for komodo seasons
+                LogPrint("chk", "%s: nHeight %d > syncChkParams.activeAt %lld sync checkpoint is active\n", __func__, nHeight, syncChkParamsOut.activeAt);
+                return true;
+            }
+        } else {
+            if (timestamp > syncChkParamsOut.activeAt) { // same 'greater' comparison as for komodo seasons
+                LogPrint("chk", "%s: timestamp %lld > syncChkParams.activeAt %lld sync checkpoint is active\n", __func__, timestamp, syncChkParamsOut.activeAt);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool IsSyncCheckpointUpgradeActive(CSyncChkParams &syncChkParamsOut, int nHeight, int64_t timestamp) {
+        return GetSyncCheckpointActivationParams(syncChkParamsOut, nHeight, timestamp);
+    }
+    bool IsSyncCheckpointUpgradeActive(int nHeight, int64_t timestamp) {
+        CSyncChkParams syncChkParamsOut;
+        return GetSyncCheckpointActivationParams(syncChkParamsOut, nHeight, timestamp);
+    }
+
+    // Try to find the private key for the master pubkey in the wallet
+    void TryInitMasterKey()
+    {
+        if (!IsMasterKeySet()) {
+            CSyncChkParams syncChkParams;
+
+            if (!CSyncCheckpointActivation::GetChainParams(syncChkParams))
+                return;
+            if (pwalletMain) {
+                LOCK(pwalletMain->cs_wallet);
+                CPubKey pubkey(ParseHex(syncChkParams.masterPubKey));
+                CKey privkey;
+                if (pwalletMain->GetKey(pubkey.GetID(), privkey)) {
+                    if (SetCheckpointPrivKey(privkey)) {
+                        LogPrintf("%s: Sync checkpoint master key set for pubkey %s\n", __func__, syncChkParams.masterPubKey);
+                    }
+                }
+            }
+        }
+    }
+
+
+    // Try to init checkpoint DB if upgrade activated after loading block index
+    // and get master key from wallet
+    bool TryInitSyncCheckpoint(const CSyncChkParams &syncChkParams) 
+    {    
+        LOCK(cs_hashSyncCheckpoint);
+        if (!fTryInitDone) {
+            if (!Checkpoints::WriteCheckpointPubKey(syncChkParams.masterPubKey)) {
+                return error("%s: failed to write new checkpoint master key", __func__);  
+            }
+            LogPrintf("%s: sync checkpoint try init done\n", __func__);
+            TryInitMasterKey();
+            fTryInitDone = true;
+        }
+        return true;
+    }
+
+    // Read sync checkpoint on startup.
+    // As wallet is not ready yet we will get master key later, when a new checkpoint is created or received first time 
+    bool OpenSyncCheckpointAtStartup(const CSyncChkParams &syncChkParams) 
+    {
+        LOCK(cs_hashSyncCheckpoint);
+        // Gulden: load hashSyncCheckpoint (must be in db already)
+        if (!Checkpoints::ReadSyncCheckpoint(Checkpoints::syncCheckpoint)) {
+            Checkpoints::CSyncCheckpoint genesisCheckpoint { Params().GenesisBlock().GetHash() };
+            if (!Checkpoints::WriteSyncCheckpoint(genesisCheckpoint)) {
+                return error("%s: failed to init sync checkpoint file", __func__);
+            }
+            if (!Checkpoints::ReadSyncCheckpoint(Checkpoints::syncCheckpoint)) {
+                return error("%s: failed to read sync checkpoint file", __func__);  
+            }    
+        }
+
+        if (mapBlockIndex.count(syncCheckpoint.GetHash()) == 0) {
+            return error("%s: sync checkpoint file corrupted. Remove sync checkpoint dir and restart", __func__);  
+        }
+        LogPrintf("%s: using synchronized checkpoint %s\n", __func__, Checkpoints::syncCheckpoint.ToString());
+
+        std::string strPubKey;
+        if (!Checkpoints::ReadCheckpointPubKey(strPubKey) || strPubKey != syncChkParams.masterPubKey) {
+            LogPrintf("%s: pubKey from file: %s\n", __func__, strPubKey);
+            LogPrintf("%s: masterPubKey: %s\n", __func__, syncChkParams.masterPubKey);
+            // write new checkpoint master keys to db
+            if (!Checkpoints::WriteCheckpointPubKey(syncChkParams.masterPubKey)) {
+                return error("%s: failed to write new checkpoint master key", __func__);
+            }
+            if (!Checkpoints::ResetSyncCheckpoint()) {
+                return error("%s: failed to reset sync-checkpoint", __func__);
+            }
+        }
+        return true;
+    }
+}

--- a/src/Gulden/auto_checkpoints_activation.cpp
+++ b/src/Gulden/auto_checkpoints_activation.cpp
@@ -41,7 +41,7 @@ namespace Checkpoints
             testnet_params = boost::none;
 
             asset_chains = {
-                { "MCL", { nSyncChkPointTimestamp, "03fdc6ca526c0cfaed2211d03dc2ea9c083aea127c7769d97dc92fed2085803ce3" }}
+                { "MCL", { nSyncChkPointTimestamp, "02c31f5dafeb638eaf394d854a2fda6a177528ad156dd6e363aa49675250f18d9d" }}
             };
         }
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -266,7 +266,8 @@ BITCOIN_CORE_H = \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
   zmq/zmqnotificationinterface.h \
-  zmq/zmqpublishnotifier.h
+  zmq/zmqpublishnotifier.h \
+  Gulden/auto_checkpoints.h
 
 
 obj/build.h: FORCE
@@ -363,6 +364,7 @@ libbitcoin_server_a_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   validationinterface.cpp \
+  Gulden/auto_checkpoints.cpp \
   $(BITCOIN_CORE_H) \
   $(LIBZCASH_H)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -365,6 +365,7 @@ libbitcoin_server_a_SOURCES = \
   txmempool.cpp \
   validationinterface.cpp \
   Gulden/auto_checkpoints.cpp \
+  Gulden/auto_checkpoints_activation.cpp \
   $(BITCOIN_CORE_H) \
   $(LIBZCASH_H)
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -43,9 +43,9 @@ public:
     static const size_t OUTPUT_SIZE = CSHA256::OUTPUT_SIZE;
 
     void Finalize(unsigned char hash[OUTPUT_SIZE]) {
-        unsigned char buf[sha.OUTPUT_SIZE];
+        unsigned char buf[CSHA256::OUTPUT_SIZE];
         sha.Finalize(buf);
-        sha.Reset().Write(buf, sha.OUTPUT_SIZE).Finalize(hash);
+        sha.Reset().Write(buf, CSHA256::OUTPUT_SIZE).Finalize(hash);
     }
 
     CHash256& Write(const unsigned char *data, size_t len) {
@@ -67,9 +67,9 @@ public:
     static const size_t OUTPUT_SIZE = CRIPEMD160::OUTPUT_SIZE;
 
     void Finalize(unsigned char hash[OUTPUT_SIZE]) {
-        unsigned char buf[sha.OUTPUT_SIZE];
+        unsigned char buf[CSHA256::OUTPUT_SIZE];
         sha.Finalize(buf);
-        CRIPEMD160().Write(buf, sha.OUTPUT_SIZE).Finalize(hash);
+        CRIPEMD160().Write(buf, CSHA256::OUTPUT_SIZE).Finalize(hash);
     }
 
     CHash160& Write(const unsigned char *data, size_t len) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1160,7 +1160,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         fPruneMode = true;
     }
 
-    ECC_Start();
     RegisterAllCoreRPCCommands(tableRPC);
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);
@@ -1233,30 +1232,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     expiryDelta = GetArg("-txexpirydelta", DEFAULT_TX_EXPIRY_DELTA);
     bSpendZeroConfChange = GetBoolArg("-spendzeroconfchange", true);
     fSendFreeTransactions = GetBoolArg("-sendfreetransactions", false);
-
-    //Gulden - generate private/public key pair for alert of checkpoint system
-    if (mapArgs.count("-genkeypair"))
-    {
-        CKey key;
-        key.MakeNewKey(false);
-
-        CPrivKey vchPrivKey = key.GetPrivKey();
-        printf("PrivateKey %s\n", HexStr<CPrivKey::iterator>(vchPrivKey.begin(), vchPrivKey.end()).c_str());
-        CPubKey vchPubKey = key.GetPubKey();
-        vchPubKey.Decompress();
-        printf("PublicKey %s\n", HexStr(vchPubKey.begin(), vchPubKey.end()).c_str());
-        return false;
-    }
-
-    //Gulden - private key for auto checkpoint system.
-    if (mapArgs.count("-checkpointkey"))
-    {
-        std::string sKey=mapArgs["-checkpointkey"];
-        if (!Checkpoints::SetCheckpointPrivKey(sKey))
-            return InitError(_("Unable to sign checkpoint, wrong checkpointkey?\n"));
-        else
-            LogPrintf("Checkpoint server enabled\n");
-    }
 
     std::string strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif // ENABLE_WALLET
@@ -1340,6 +1315,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // Initialize elliptic curve code
     std::string sha256_algo = SHA256AutoDetect();
     LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);
+    ECC_Start();
     globalVerifyHandle.reset(new ECCVerifyHandle());
 
     // set the hash algorithm to use for this chain

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -28,6 +28,7 @@
 #include "addrman.h"
 #include "amount.h"
 #include "checkpoints.h"
+#include "Gulden/auto_checkpoints.h"
 #include "compat/sanity.h"
 #include "consensus/upgrades.h"
 #include "consensus/validation.h"
@@ -1159,6 +1160,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         fPruneMode = true;
     }
 
+    ECC_Start();
     RegisterAllCoreRPCCommands(tableRPC);
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);
@@ -1231,6 +1233,30 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     expiryDelta = GetArg("-txexpirydelta", DEFAULT_TX_EXPIRY_DELTA);
     bSpendZeroConfChange = GetBoolArg("-spendzeroconfchange", true);
     fSendFreeTransactions = GetBoolArg("-sendfreetransactions", false);
+
+    //Gulden - generate private/public key pair for alert of checkpoint system
+    if (mapArgs.count("-genkeypair"))
+    {
+        CKey key;
+        key.MakeNewKey(false);
+
+        CPrivKey vchPrivKey = key.GetPrivKey();
+        printf("PrivateKey %s\n", HexStr<CPrivKey::iterator>(vchPrivKey.begin(), vchPrivKey.end()).c_str());
+        CPubKey vchPubKey = key.GetPubKey();
+        vchPubKey.Decompress();
+        printf("PublicKey %s\n", HexStr(vchPubKey.begin(), vchPubKey.end()).c_str());
+        return false;
+    }
+
+    //Gulden - private key for auto checkpoint system.
+    if (mapArgs.count("-checkpointkey"))
+    {
+        std::string sKey=mapArgs["-checkpointkey"];
+        if (!Checkpoints::SetCheckpointPrivKey(sKey))
+            return InitError(_("Unable to sign checkpoint, wrong checkpointkey?\n"));
+        else
+            LogPrintf("Checkpoint server enabled\n");
+    }
 
     std::string strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif // ENABLE_WALLET
@@ -1314,7 +1340,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // Initialize elliptic curve code
     std::string sha256_algo = SHA256AutoDetect();
     LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);
-    ECC_Start();
     globalVerifyHandle.reset(new ECCVerifyHandle());
 
     // set the hash algorithm to use for this chain

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -391,3 +391,7 @@ void ECC_Stop() {
         secp256k1_context_destroy(ctx);
     }
 }
+
+bool ECC_initialized() {
+    return secp256k1_context_sign != NULL;
+}

--- a/src/key.h
+++ b/src/key.h
@@ -216,6 +216,8 @@ void ECC_Start(void);
 /** Deinitialize the elliptic curve support. No-op if ECC_Start wasn't called first. */
 void ECC_Stop(void);
 
+bool ECC_initialized(void);
+
 /** Check that required EC support is available at runtime. */
 bool ECC_InitSanityCheck(void);
 

--- a/src/komodo_defs.h
+++ b/src/komodo_defs.h
@@ -96,14 +96,14 @@ static const int32_t KMD_SEASON_HEIGHTS[NUM_KMD_SEASONS] = {
     8113400};
 
 // MCL height HF sample
-const int32_t nSunsettingHeight = 3112766; // Approx 12 Jan 2026, not used actually
+const int32_t nSunsettingHeight = 3112766; // not used
 // Asset chain timestamp
-const uint32_t nSunsettingTimestamp = 1767528000; // 12 Jan 2026 12:00 UTC
+const uint32_t nSunsettingTimestamp = 1767528000; // 04 Jan 2026 12:00 UTC
 
-// KMD mainnet height
-const int32_t nSyncChkPointHeight = nSunsettingHeight; // TODO fix if used
-// Asset chain timestamp
-const uint32_t nSyncChkPointTimestamp = nSunsettingTimestamp; // TODO fix if used
+// MCL height HF sample
+const int32_t nSyncChkPointHeight = nSunsettingHeight; // not used
+// Asset chain auto checkpoint timestamp
+const uint32_t nSyncChkPointTimestamp = nSunsettingTimestamp;
 
 // Era array of pubkeys. Add extra seasons to bottom as requried, after adding appropriate info above. 
 static const char *notaries_elected[NUM_KMD_SEASONS][NUM_KMD_NOTARIES][2] =

--- a/src/komodo_defs.h
+++ b/src/komodo_defs.h
@@ -95,6 +95,16 @@ static const int32_t KMD_SEASON_HEIGHTS[NUM_KMD_SEASONS] = {
     nS8HardforkHeight,
     8113400};
 
+// MCL height HF sample
+const int32_t nSunsettingHeight = 3112766; // Approx 12 Jan 2026, not used actually
+// Asset chain timestamp
+const uint32_t nSunsettingTimestamp = 1767528000; // 12 Jan 2026 12:00 UTC
+
+// KMD mainnet height
+const int32_t nSyncChkPointHeight = nSunsettingHeight; // TODO fix if used
+// Asset chain timestamp
+const uint32_t nSyncChkPointTimestamp = nSunsettingTimestamp; // TODO fix if used
+
 // Era array of pubkeys. Add extra seasons to bottom as requried, after adding appropriate info above. 
 static const char *notaries_elected[NUM_KMD_SEASONS][NUM_KMD_NOTARIES][2] =
 {

--- a/src/komodo_notary.h
+++ b/src/komodo_notary.h
@@ -16,6 +16,7 @@
 
 #include "komodo_defs.h"
 #include "komodo_cJSON.h"
+#include "main.h"
 
 #include "notaries_staked.h"
 
@@ -366,7 +367,10 @@ int32_t komodo_dpowconfs(int32_t txheight,int32_t numconfs)
 {
     static int32_t hadnotarization;
     char symbol[KOMODO_ASSETCHAIN_MAXLEN],dest[KOMODO_ASSETCHAIN_MAXLEN]; struct komodo_state *sp;
-    if ( KOMODO_DPOWCONFS != 0 && txheight > 0 && numconfs > 0 && (sp= komodo_stateptr(symbol,dest)) != 0 )
+
+    int nHeightTip = chainActive.Height();
+    int64_t timestamp = komodo_heightstamp(nHeightTip);
+    if ( !IsSunsettingActive(nHeightTip, timestamp) &&  KOMODO_DPOWCONFS != 0 && txheight > 0 && numconfs > 0 && (sp= komodo_stateptr(symbol,dest)) != 0 )
     {
         if ( sp->NOTARIZED_HEIGHT > 0 )
         {

--- a/src/main.h
+++ b/src/main.h
@@ -951,4 +951,8 @@ uint64_t CalculateCurrentUsage();
 /** Return a CMutableTransaction with contextual default values based on set of consensus rules at height */
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight);
 
+int32_t komodo_isnotaryvout(char *coinaddr,uint32_t tiptime); // from ac_private chains only
+bool komodo_dailysnapshot(int32_t height);
+bool IsSunsettingActive(int nHeight, int64_t timestamp);
+
 #endif // BITCOIN_MAIN_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2136,6 +2136,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nPingUsecTime = 0;
     fPingQueued = false;
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
+    hashCheckpointKnown = uint256();
 
     {
         LOCK(cs_nLastNodeId);

--- a/src/net.h
+++ b/src/net.h
@@ -329,6 +329,7 @@ public:
     CRollingBloomFilter addrKnown;
     bool fGetAddr;
     std::set<uint256> setKnown;
+    uint256 hashCheckpointKnown;
 
     // inventory based relay
     mruset<CInv> setInventoryKnown;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -37,6 +37,7 @@
 #endif // ENABLE_RUST
 uint32_t komodo_chainactive_timestamp();
 
+#include "main.h"
 #include "komodo_defs.h"
 
 unsigned int lwmaGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params);
@@ -827,7 +828,7 @@ bool CheckProofOfWork(const CBlockHeader &blkHeader, uint8_t *pubkey33, int32_t 
         height = komodo_currentheight() + 1;
         //fprintf(stderr,"set height to %d\n",height);
     }
-    if ( height > 34000 && ASSETCHAINS_SYMBOL[0] == 0 ) // 0 -> non-special notary
+    if (!IsSunsettingActive(height, tiptime) && height > 34000 && ASSETCHAINS_SYMBOL[0] == 0 ) // 0 -> non-special notary
     {
         special = komodo_chosennotary(&notaryid,height,pubkey33,tiptime);
         for (i=0; i<33; i++)
@@ -860,6 +861,7 @@ bool CheckProofOfWork(const CBlockHeader &blkHeader, uint8_t *pubkey33, int32_t 
             }
             if ( (flag != 0 || special2 > 0) && special2 != -2 )
             {
+                LogPrint("dpow", "%s bnTarget set to KOMODO_MINDIFF_NBITS flag=%d special2=%d notaryid=%d\n", __func__, flag, special2, notaryid);
                 bnTarget.SetCompact(KOMODO_MINDIFF_NBITS,&fNegative,&fOverflow);
                 /*
                 const void* pblock = &blkHeader;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -285,9 +285,6 @@ static bool rest_block_notxdetails(HTTPRequest* req, const std::string& strURIPa
     return rest_block(req, strURIPart, false);
 }
 
-// A bit of a hack - dependency on a function defined in rpc/blockchain.cpp
-UniValue getblockchaininfo(const UniValue& params, bool fHelp, const CPubKey& mypk);
-
 static bool rest_chaininfo(HTTPRequest* req, const std::string& strURIPart)
 {
     if (!CheckWarmup(req))

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1506,11 +1506,11 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp, const CPubKey& my
 
     // sync checkpoint and dpow status
     UniValue syncCheckpoint(UniValue::VOBJ);
-    bool isSunsettingActive = IsSunsettingActive(tip->nHeight, tip->GetBlockTime()); // dPoW is active when !isSunsettingActive
+    bool isSunsettingActive = IsSunsettingActive(tip->GetHeight(), tip->GetBlockTime()); // dPoW is active when !isSunsettingActive
     syncCheckpoint.push_back(Pair("dpow_active", !isSunsettingActive ? "true" : "false"));
 
     Checkpoints::CSyncChkParams syncChkParams;
-    bool isSyncCheckpointActive = Checkpoints::IsSyncCheckpointUpgradeActive(syncChkParams, tip->nHeight, tip->GetBlockTime());
+    bool isSyncCheckpointActive = Checkpoints::IsSyncCheckpointUpgradeActive(syncChkParams, tip->GetHeight(), tip->GetBlockTime());
     syncCheckpoint.push_back(Pair("sync_checkpoint_active", isSyncCheckpointActive));
     bool fValidParams = (!syncChkParams.masterPubKey.empty() && syncChkParams.activeAt != -1);
     syncCheckpoint.push_back(Pair("sync_checkpoint_expected", fValidParams));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1385,6 +1385,10 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp, const CPubKey& my
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
             "  \"commitments\": xxxxxx,    (numeric) the current number of note commitments in the commitment tree\n"
+            "  \"syncCheckpoint\": {\n"
+            "     \"height\": xxxx,        (numeric) latest sync checkpoint height\n"
+            "     \"blockHash\": \"...\"   (string) latest sync checkpoint block hash\n"
+            "  },\n"
             "  \"softforks\": [            (array) status of softforks in progress\n"
             "     {\n"
             "        \"id\": \"xxxx\",        (string) name of softfork\n"
@@ -1410,7 +1414,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp, const CPubKey& my
             "     \"chaintip\": \"xxxxxxxx\",   (string) branch ID used to validate the current chain tip\n"
             "     \"nextblock\": \"xxxxxxxx\"   (string) branch ID that the next block will be validated under\n"
             "  },\n"
-            "  \"synccheckpoint\": {                      (object) sync checkpoint and dPoW status\n"
+            "  \"syncCheckpointUpgrade\": {               (object) sync checkpoint and dPoW status\n"
             "     \"dpow_active\": xx,                    (boolean) whether dPoW (delayed Proof of Work) is active\n"
             "     \"sync_checkpoint_active\": xx,         (boolean) whether sync checkpoint upgrade is active\n"
             "     \"sync_checkpoint_expected\": xx,       (boolean) whether sync checkpoint upgrade is expected\n"
@@ -1505,34 +1509,34 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp, const CPubKey& my
     }
 
     // sync checkpoint and dpow status
-    UniValue syncCheckpoint(UniValue::VOBJ);
+    UniValue syncCheckpointUpgrade(UniValue::VOBJ);
     bool isSunsettingActive = IsSunsettingActive(tip->GetHeight(), tip->GetBlockTime()); // dPoW is active when !isSunsettingActive
-    syncCheckpoint.push_back(Pair("dpow_active", !isSunsettingActive ? "true" : "false"));
+    syncCheckpointUpgrade.push_back(Pair("dpow_active", !isSunsettingActive ? "true" : "false"));
 
     Checkpoints::CSyncChkParams syncChkParams;
     bool isSyncCheckpointActive = Checkpoints::IsSyncCheckpointUpgradeActive(syncChkParams, tip->GetHeight(), tip->GetBlockTime());
-    syncCheckpoint.push_back(Pair("sync_checkpoint_active", isSyncCheckpointActive));
+    syncCheckpointUpgrade.push_back(Pair("sync_checkpoint_active", isSyncCheckpointActive));
     bool fValidParams = (!syncChkParams.masterPubKey.empty() && syncChkParams.activeAt != -1);
-    syncCheckpoint.push_back(Pair("sync_checkpoint_expected", fValidParams));
+    syncCheckpointUpgrade.push_back(Pair("sync_checkpoint_expected", fValidParams));
 
     if (fValidParams) {
         if (syncChkParams.activeAt < LOCKTIME_THRESHOLD) {
-            syncCheckpoint.push_back(Pair("activation_height", syncChkParams.activeAt));
+            syncCheckpointUpgrade.push_back(Pair("activation_height", syncChkParams.activeAt));
         } else {
-            syncCheckpoint.push_back(Pair("activation_timestamp", syncChkParams.activeAt));
-            syncCheckpoint.push_back(Pair("activation_timestamp_utc", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", syncChkParams.activeAt)));
+            syncCheckpointUpgrade.push_back(Pair("activation_timestamp", syncChkParams.activeAt));
+            syncCheckpointUpgrade.push_back(Pair("activation_timestamp_utc", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", syncChkParams.activeAt)));
         }
-        syncCheckpoint.push_back(Pair("masterpubKey", syncChkParams.masterPubKey));
+        syncCheckpointUpgrade.push_back(Pair("masterpubKey", syncChkParams.masterPubKey));
 
         if (isSyncCheckpointActive) {
             if (TryInitSyncCheckpoint(syncChkParams)) {
-                syncCheckpoint.push_back(Pair("init", true));
+                syncCheckpointUpgrade.push_back(Pair("init", true));
             } else {
-                syncCheckpoint.push_back(Pair("init", false));
+                syncCheckpointUpgrade.push_back(Pair("init", false));
             }
         }
     }
-    obj.push_back(Pair("synccheckpoint", syncCheckpoint));
+    obj.push_back(Pair("syncCheckpointUpgrade", syncCheckpointUpgrade));
 
     return obj;
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -31,6 +31,7 @@
 #include "notaries_staked.h"
 #include "cc/eval.h"
 #include "cc/CCinclude.h"
+#include "Gulden/auto_checkpoints.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
@@ -1663,6 +1664,25 @@ UniValue decodeccopret(const UniValue& params, bool fHelp, const CPubKey& mypk)
     return result;
 }
 
+static UniValue getcheckpoint(const UniValue& params, bool fHelp, const CPubKey& mypk)
+{
+    if (fHelp) throw std::runtime_error("returns last sync checkpoint");
+    if (params.size() != 0)
+    {
+        throw std::runtime_error("getcheckpoint does not take arguments\n");
+    }
+
+    LOCK(Checkpoints::cs_hashSyncCheckpoint);
+            
+    UniValue chkptInfo(UniValue::VOBJ);
+    chkptInfo.push_back(Pair("checkpoint", Checkpoints::syncCheckpoint.hash.GetHex()));
+    CBlockIndex *psyncCheckpoint = Checkpoints::GetLastSyncCheckpoint();
+    if (psyncCheckpoint) {
+        chkptInfo.push_back(Pair("height", psyncCheckpoint->GetHeight()));
+    }
+    return chkptInfo;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
@@ -1671,6 +1691,7 @@ static const CRPCCommand commands[] =
     { "util",               "z_validateaddress",      &z_validateaddress,      true  }, /* uses wallet if enabled */
     { "util",               "createmultisig",         &createmultisig,         true  },
     { "util",               "verifymessage",          &verifymessage,          true  },
+    { "util",               "getcheckpoint",          &getcheckpoint,          true  },
 
     /* Not shown in help */
     { "hidden",             "setmocktime",            &setmocktime,            true  },

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -815,28 +815,3 @@ bool CBlockTreeDB::ReadAllUnspentIndex(std::vector<std::pair<CAddressUnspentKey,
     return true;
 }
 
-
-CCheckpointsDB::CCheckpointsDB() : db(GetDataDir() / "sync_checkpoints", 2, false, false)
-{
-	
-}
-
-bool CCheckpointsDB::ReadSyncCheckpoint(uint256& hashCheckpoint)
-{
-    return db.Read(string("hashSyncCheckpoint"), hashCheckpoint);
-}
-
-bool CCheckpointsDB::WriteSyncCheckpoint(uint256 hashCheckpoint)
-{
-    return db.Write(string("hashSyncCheckpoint"), hashCheckpoint);
-}
-
-bool CCheckpointsDB::ReadCheckpointPubKey(std::string& strPubKey)
-{
-    return db.Read(string("SyncCheckpointPubKey"), strPubKey);
-}
-
-bool CCheckpointsDB::WriteCheckpointPubKey(std::string& strPubKey)
-{
-    return db.Write(string("SyncCheckpointPubKey"), strPubKey);
-}

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -816,3 +816,27 @@ bool CBlockTreeDB::ReadAllUnspentIndex(std::vector<std::pair<CAddressUnspentKey,
 }
 
 
+CCheckpointsDB::CCheckpointsDB() : db(GetDataDir() / "sync_checkpoints", 2, false, false)
+{
+	
+}
+
+bool CCheckpointsDB::ReadSyncCheckpoint(uint256& hashCheckpoint)
+{
+    return db.Read(string("hashSyncCheckpoint"), hashCheckpoint);
+}
+
+bool CCheckpointsDB::WriteSyncCheckpoint(uint256 hashCheckpoint)
+{
+    return db.Write(string("hashSyncCheckpoint"), hashCheckpoint);
+}
+
+bool CCheckpointsDB::ReadCheckpointPubKey(std::string& strPubKey)
+{
+    return db.Read(string("SyncCheckpointPubKey"), strPubKey);
+}
+
+bool CCheckpointsDB::WriteCheckpointPubKey(std::string& strPubKey)
+{
+    return db.Write(string("SyncCheckpointPubKey"), strPubKey);
+}

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -82,6 +82,19 @@ public:
     bool GetStats(CCoinsStats &stats) const;
 };
 
+//Gulden - Checkpointing
+class CCheckpointsDB
+{
+protected:
+    CDBWrapper db;
+public:
+    CCheckpointsDB();
+    bool ReadSyncCheckpoint(uint256& hashCheckpoint);
+    bool WriteSyncCheckpoint(uint256 hashCheckpoint);
+    bool ReadCheckpointPubKey(std::string& strPubKey);
+    bool WriteCheckpointPubKey(std::string& strPubKey);
+};
+
 /** Access to the block database (blocks/index/) */
 class CBlockTreeDB : public CDBWrapper
 {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -82,18 +82,6 @@ public:
     bool GetStats(CCoinsStats &stats) const;
 };
 
-//Gulden - Checkpointing
-class CCheckpointsDB
-{
-protected:
-    CDBWrapper db;
-public:
-    CCheckpointsDB();
-    bool ReadSyncCheckpoint(uint256& hashCheckpoint);
-    bool WriteSyncCheckpoint(uint256 hashCheckpoint);
-    bool ReadCheckpointPubKey(std::string& strPubKey);
-    bool WriteCheckpointPubKey(std::string& strPubKey);
-};
 
 /** Access to the block database (blocks/index/) */
 class CBlockTreeDB : public CDBWrapper

--- a/src/version.h
+++ b/src/version.h
@@ -24,7 +24,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 170011;
+static const int PROTOCOL_VERSION = 170012;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -28,7 +28,8 @@
 #include "util.h"
 #include "utiltime.h"
 #include "wallet.h"
-
+#include "komodo_nSPV_defs.h"
+#include "Gulden/auto_checkpoints.h"
 #include <fstream>
 #include <stdint.h>
 
@@ -239,6 +240,10 @@ UniValue importprivkey(const UniValue& params, bool fHelp, const CPubKey& mypk)
         if (fRescan) {
             pwalletMain->ScanForWalletTransactions(chainActive[height], true);
         }
+    }
+
+    if (!Checkpoints::IsMasterKeySet()) {
+        Checkpoints::TryInitMasterKey();
     }
 
     return EncodeDestination(vchAddress);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -59,6 +59,9 @@
 
 #include <numeric>
 
+#include "main.h"
+#include "Gulden/auto_checkpoints.h"
+#include "rpc/rawtransaction.h"
 #include "komodo_defs.h"
 #include <string.h>
 
@@ -1849,6 +1852,11 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
 
     bool bIsCoinbase = wtx.IsCoinBase();
 
+    // If rpconlylistsecuredtransactions is present then only include if tx is secured by a checkpoint
+    bool securedTransaction = (Checkpoints::IsSecuredBySyncCheckpoint(wtx.hashBlock));
+    if (mapMultiArgs.count("-rpconlylistsecuredtransactions") && !securedTransaction)
+        return;
+
     wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter);
 
     bool fAllAccounts = (strAccount == string("*"));
@@ -1871,6 +1879,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
             if (fLong)
                 WalletTxToJSON(wtx, entry);
             entry.push_back(Pair("size", static_cast<uint64_t>(GetSerializeSize(static_cast<CTransaction>(wtx), SER_NETWORK, PROTOCOL_VERSION))));
+            entry.push_back(Pair("secured_by_checkpoint", securedTransaction ? "yes" : "no"));
             ret.push_back(entry);
         }
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -61,7 +61,6 @@
 
 #include "main.h"
 #include "Gulden/auto_checkpoints.h"
-#include "rpc/rawtransaction.h"
 #include "komodo_defs.h"
 #include <string.h>
 
@@ -1929,6 +1928,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 if (fLong)
                     WalletTxToJSON(wtx, entry);
                 entry.push_back(Pair("size", static_cast<uint64_t>(GetSerializeSize(static_cast<CTransaction>(wtx), SER_NETWORK, PROTOCOL_VERSION))));
+                entry.push_back(Pair("secured_by_checkpoint", securedTransaction ? "yes" : "no"));
                 ret.push_back(entry);
             }
         }


### PR DESCRIPTION
### Auto Checkpoints feature
This PR adds Auto Checkpoints feature to the MCL network (timestamp activated).
Auto Checkpoints is a lightweight finality mechanism in Komodo-based blockchains based on dynamically created checkpoints as the chain progresses.

A single designated master node for each block issues a synchronization checkpoint, ensuring that no chain reorganisation is permitted below the most recent checkpoint. This effectively guarantees transaction finality up to a checkpoint depth of 4 blocks behind the chain tip.

Komodo’s implementation is derived from the Gulden (Munt) codebase and is used for both KMD mainnet and asset chains.

Updated and new RPCs:
- `getblockchaininfo`: added `syncCheckpoint` and `syncCheckpointUpgrade` fields,
- `getcheckpoint`: returns the latest sync checkpoint.

**More info**: https://github.com/dimxy/komodo/wiki/Auto-Checkpoints-description

### DPoW sunsetting
This PR also adds sunsetting for Komodo DPoW consensus code (timestamp deactivated):
- komodo_checkpoint(),
- code in ActivateBaseChainStep().

### TODO:
- [x] fix master key for MCL
- [x] set dPoW deactivation timestamp (4 Jan 2026 12:00 UTC)
- [x] set auto-checkpoints activation timestamp (4 Jan 2026 12:00 UTC)