### PR TITLE
fix(dpow): disable dpow confirmations after sunsetting

### DIFF
--- a/src/komodo_defs.h
+++ b/src/komodo_defs.h
@@ -95,6 +95,11 @@ static const int32_t KMD_SEASON_HEIGHTS[NUM_KMD_SEASONS] = {
     nS8HardforkHeight,
     8113400};
 
+// height HF (for build)
+const int32_t nSunsettingHeight = 2081563; // not used
+// Asset chain sunsetting timestamp
+const uint32_t nSunsettingTimestamp = 1767528000; // 04 Jan 2026 12:00 UTC
+
 // Era array of pubkeys. Add extra seasons to bottom as requried, after adding appropriate info above. 
 static const char *notaries_elected[NUM_KMD_SEASONS][NUM_KMD_NOTARIES][2] =
 {

--- a/src/komodo_notary.h
+++ b/src/komodo_notary.h
@@ -16,6 +16,7 @@
 
 #include "komodo_defs.h"
 #include "komodo_cJSON.h"
+#include "main.h"
 
 #include "notaries_staked.h"
 
@@ -366,7 +367,10 @@ int32_t komodo_dpowconfs(int32_t txheight,int32_t numconfs)
 {
     static int32_t hadnotarization;
     char symbol[KOMODO_ASSETCHAIN_MAXLEN],dest[KOMODO_ASSETCHAIN_MAXLEN]; struct komodo_state *sp;
-    if ( KOMODO_DPOWCONFS != 0 && txheight > 0 && numconfs > 0 && (sp= komodo_stateptr(symbol,dest)) != 0 )
+
+    int nHeightTip = chainActive.Height();
+    int64_t timestamp = komodo_heightstamp(nHeightTip);
+    if ( !IsSunsettingActive(nHeightTip, timestamp) &&  KOMODO_DPOWCONFS != 0 && txheight > 0 && numconfs > 0 && (sp= komodo_stateptr(symbol,dest)) != 0 )
     {
         if ( sp->NOTARIZED_HEIGHT > 0 )
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8774,3 +8774,13 @@ CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Para
     }
     return mtx;
 }
+
+bool IsSunsettingActive(int nHeight, int64_t timestamp) {
+    AssertLockHeld(cs_main);
+
+    if (ASSETCHAINS_SYMBOL[0] == '\0' ) {
+        return nHeight > nSunsettingHeight;
+    } else {
+        return timestamp > nSunsettingTimestamp;
+    }
+}

--- a/src/main.h
+++ b/src/main.h
@@ -951,4 +951,6 @@ uint64_t CalculateCurrentUsage();
 /** Return a CMutableTransaction with contextual default values based on set of consensus rules at height */
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight);
 
+bool IsSunsettingActive(int nHeight, int64_t timestamp);
+
 #endif // BITCOIN_MAIN_H


### PR DESCRIPTION
This PR disables notarised confirmations for the getrawtransaction RPC after the Komodo DPoW sunsetting on Jan 4 2026.
In DPoW, when blocks are not notarised yet the getrawtransaction RPC returns the constant value of 1 for the confirmations value.
As there is no notarisations occur after the sunsetting day we should return ordinary confirmations from then on.